### PR TITLE
Additional review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/secrets
+/target
+.env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,6 +61,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -43,9 +77,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.79"
+version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
+checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -53,10 +87,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f379c4e505c0692333bd90a334baa234990faa06bdabefd3261f765946aa920"
+dependencies = [
+ "aws-lc-sys",
+ "mirai-annotations",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68aa3d613f42dbf301dbbcaf3dc260805fd33ffd95f6d290ad7231a9e5d877a7"
+dependencies = [
+ "bindgen",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "libc",
+ "paste",
+]
 
 [[package]]
 name = "backtrace"
@@ -75,9 +144,50 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+
+[[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "bindgen"
+version = "0.69.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+dependencies = [
+ "bitflags 2.5.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.58",
+ "which",
+]
 
 [[package]]
 name = "bitflags"
@@ -90,6 +200,9 @@ name = "bitflags"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "block-buffer"
@@ -102,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.15.4"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytecount"
@@ -157,9 +270,18 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.90"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+checksum = "2678b2e3449475e95b0aa6f9b506a28e61b3dc8996592b983695e8ebb58a8b41"
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "cfg-if"
@@ -175,9 +297,31 @@ checksum = "8a0d04d43504c61aa6c7531f1871dd0d418d91130162063b789da00fd7057a5e"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
- "windows-targets 0.52.4",
+ "wasm-bindgen",
+ "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -189,6 +333,61 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "config"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7328b20597b53c2454f0b1919720c25c7339051c02b72b7e05409e00b14132be"
+dependencies = [
+ "async-trait",
+ "convert_case",
+ "json5",
+ "lazy_static",
+ "nom",
+ "pathdiff",
+ "ron",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "toml",
+ "yaml-rust",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -217,6 +416,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "crc32fast"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,10 +449,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
@@ -251,13 +480,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.58",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.58",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown",
+ "hashbrown 0.14.3",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -269,6 +533,17 @@ name = "data-encoding"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
+
+[[package]]
+name = "der"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
 
 [[package]]
 name = "deranged"
@@ -287,16 +562,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
 name = "discalen"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "chrono",
+ "config",
  "dotenvy",
+ "futures",
+ "google-calendar3",
+ "humantime",
+ "humantime-serde",
+ "hyper 1.2.0",
+ "hyper-rustls 0.27.1",
+ "secrecy",
+ "serde",
  "serenity",
+ "sqlx",
+ "thiserror",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "yup-oauth2",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -306,10 +608,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.33"
+name = "dunce"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+
+[[package]]
+name = "either"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
 dependencies = [
  "cfg-if",
 ]
@@ -340,10 +657,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
 name = "fastrand"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
+
+[[package]]
+name = "finl_unicode"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
 
 [[package]]
 name = "flate2"
@@ -353,6 +693,17 @@ checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -367,8 +718,14 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
- "percent-encoding",
+ "percent-encoding 2.3.1",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -378,6 +735,7 @@ checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -399,6 +757,28 @@ name = "futures-core"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
+]
 
 [[package]]
 name = "futures-io"
@@ -468,9 +848,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
 dependencies = [
  "cfg-if",
  "libc",
@@ -490,6 +870,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "google-apis-common"
+version = "6.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78672323eaeeb181cadd4d07333f1bcc8c2840a55b58afa8ab052664cd4a54ad"
+dependencies = [
+ "base64 0.13.1",
+ "chrono",
+ "http 0.2.12",
+ "hyper 0.14.28",
+ "itertools 0.10.5",
+ "mime",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "tokio",
+ "tower-service",
+ "url 1.7.2",
+ "yup-oauth2",
+]
+
+[[package]]
+name = "google-calendar3"
+version = "5.0.4+20240223"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9472d0354452879ca1b5f77fc9401289acb3106b46eae28552979252385dd39b"
+dependencies = [
+ "anyhow",
+ "google-apis-common",
+ "http 0.2.12",
+ "hyper 0.14.28",
+ "hyper-rustls 0.24.2",
+ "itertools 0.10.5",
+ "mime",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower-service",
+ "url 1.7.2",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -501,7 +922,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap",
+ "indexmap 2.2.6",
  "slab",
  "tokio",
  "tokio-util",
@@ -510,15 +931,82 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+
+[[package]]
+name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+dependencies = [
+ "hashbrown 0.14.3",
+]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "http"
@@ -554,6 +1042,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
 name = "httparse"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,6 +1062,22 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "humantime-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
+dependencies = [
+ "humantime",
+ "serde",
+]
 
 [[package]]
 name = "hyper"
@@ -577,7 +1091,7 @@ dependencies = [
  "futures-util",
  "h2",
  "http 0.2.12",
- "http-body",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -590,6 +1104,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186548d73ac615b32a73aafe38fb4f56c0d340e110e5a200bcadbaf2e199263a"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,10 +1130,68 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper",
+ "hyper 0.14.28",
+ "log",
  "rustls 0.21.10",
+ "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "399c78f9338483cb7e630c8474b07268983c6bd5acee012e4211f9f7bb21b070"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.28",
+ "log",
+ "rustls 0.22.3",
+ "rustls-native-certs 0.7.0",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.25.0",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "908bb38696d7a037a01ebcc68a00634112ac2bbf8ca74e30a2c3d2f4f021302b"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.2.0",
+ "hyper-util",
+ "log",
+ "rustls 0.23.4",
+ "rustls-native-certs 0.7.0",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.0",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.2.0",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -627,6 +1218,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,12 +1246,23 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -651,6 +1270,24 @@ name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -668,6 +1305,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin 0.5.2",
+]
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "levenshtein"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -678,6 +1341,39 @@ name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+
+[[package]]
+name = "libloading"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -700,6 +1396,22 @@ name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+
+[[package]]
+name = "matches"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
 
 [[package]]
 name = "memchr"
@@ -739,6 +1451,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -759,10 +1477,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "mirai-annotations"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -771,6 +1552,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -780,6 +1562,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
  "libc",
 ]
 
@@ -797,6 +1588,28 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "ordered-multimap"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ed8acf08e98e744e5384c8bc63ceb0364e68a6854187221c18df61c4797690e"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -822,10 +1635,102 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pest"
+version = "2.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "311fb059dee1a7b802f036316d790138c613a4e8b180c822e3925a662e9f0c95"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f73541b156d32197eecda1a4014d7f868fd2bcb3c550d5386087cfba442bf69c"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c35eeed0a3fab112f75165fdc026b3913f4183133f19b49be773ac9ea966e8bd"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2adbf29bb9776f28caece835398781ab24435585fe0d4dc1374a61db5accedca"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -840,6 +1745,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,6 +1782,16 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3928fb5db768cb86f891ff014f0144589297e3c6a1aba6ed7cecfdace270c7"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.58",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -873,9 +1815,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -920,31 +1862,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+
+[[package]]
 name = "reqwest"
 version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
  "h2",
  "http 0.2.12",
- "http-body",
- "hyper",
- "hyper-rustls",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
+ "hyper-rustls 0.24.2",
  "ipnet",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
  "once_cell",
- "percent-encoding",
+ "percent-encoding 2.3.1",
  "pin-project-lite",
  "rustls 0.21.10",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -954,7 +1925,7 @@ dependencies = [
  "tokio-rustls 0.24.1",
  "tokio-util",
  "tower-service",
- "url",
+ "url 2.5.0",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams",
@@ -973,9 +1944,51 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "libc",
- "spin",
+ "spin 0.9.8",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "ron"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
+dependencies = [
+ "base64 0.21.7",
+ "bitflags 2.5.0",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e5124fcb30e76a7e79bfee683a2746db83784b86289f6251b54b7950a0dfc"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e2a3bcec1f113553ef1c88aae6c020a369d03d55b58de9869a0908930385091"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -983,6 +1996,12 @@ name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
@@ -1024,12 +2043,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c4d6d8ad9f2492485e13453acbb291dd08f64441b6609c491f1c2cd2c6b4fe1"
+dependencies = [
+ "aws-lc-rs",
+ "log",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.1.2",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64",
+ "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+dependencies = [
+ "base64 0.22.0",
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -1054,6 +2123,7 @@ version = "0.102.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -1075,6 +2145,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1091,6 +2170,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
 name = "secrecy"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1098,6 +2183,29 @@ checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
 dependencies = [
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f3cc463c0ef97e11c3461a9d3787412d30e8e7eb907c79180c4a57bf7c04ef"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1141,6 +2249,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1153,6 +2270,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07ff71d2c147a7b57362cead5e22f772cd52f6ab31cfcd9edcd7f6aeb2a0afbe"
+dependencies = [
+ "base64 0.13.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "serde",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
+]
+
+[[package]]
 name = "serenity"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1160,7 +2305,7 @@ checksum = "c64da29158bb55d70677cacd4f4f8eab1acef005fb830d9c3bea411b090e96a9"
 dependencies = [
  "arrayvec",
  "async-trait",
- "base64",
+ "base64 0.21.7",
  "bitflags 2.5.0",
  "bytes",
  "chrono",
@@ -1172,7 +2317,7 @@ dependencies = [
  "levenshtein",
  "mime_guess",
  "parking_lot",
- "percent-encoding",
+ "percent-encoding 2.3.1",
  "reqwest",
  "secrecy",
  "serde",
@@ -1184,7 +2329,7 @@ dependencies = [
  "tracing",
  "typemap_rev",
  "typesize",
- "url",
+ "url 2.5.0",
  "uwl",
 ]
 
@@ -1197,6 +2342,42 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core",
 ]
 
 [[package]]
@@ -1241,15 +2422,259 @@ dependencies = [
 
 [[package]]
 name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "sqlformat"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce81b7bd7c4493975347ef60d8c7e8b742d4694f4c49f93e0a12ea263938176c"
+dependencies = [
+ "itertools 0.12.1",
+ "nom",
+ "unicode_categories",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9a2ccff1a000a5a59cd33da541d9f2fdcd9e6e8229cc200565942bff36d0aaa"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24ba59a9342a3d9bab6c56c118be528b27c9b60e490080e9711a04dccac83ef6"
+dependencies = [
+ "ahash",
+ "atoi",
+ "byteorder",
+ "bytes",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-channel",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashlink",
+ "hex",
+ "indexmap 2.2.6",
+ "log",
+ "memchr",
+ "once_cell",
+ "paste",
+ "percent-encoding 2.3.1",
+ "rustls 0.21.10",
+ "rustls-pemfile 1.0.4",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlformat",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url 2.5.0",
+ "webpki-roots 0.25.4",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea40e2345eb2faa9e1e5e326db8c34711317d2b5e08d0d5741619048a803127"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5833ef53aaa16d860e92123292f1f6a3d53c34ba8b1969f152ef1a7bb803f3c8"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn 1.0.109",
+ "tempfile",
+ "tokio",
+ "url 2.5.0",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ed31390216d20e538e447a7a9b959e06ed9fc51c37b514b46eb758016ecd418"
+dependencies = [
+ "atoi",
+ "base64 0.21.7",
+ "bitflags 2.5.0",
+ "byteorder",
+ "bytes",
+ "crc",
+ "digest",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding 2.3.1",
+ "rand",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c824eb80b894f926f89a0b9da0c7f435d27cdd35b8c655b114e58223918577e"
+dependencies = [
+ "atoi",
+ "base64 0.21.7",
+ "bitflags 2.5.0",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b244ef0a8414da0bed4bb1910426e890b19e5e9bccc27ada6b797d05c55ae0aa"
+dependencies = [
+ "atoi",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding 2.3.1",
+ "serde",
+ "sqlx-core",
+ "tracing",
+ "url 2.5.0",
+ "urlencoding",
+]
 
 [[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stringprep"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb41d74e231a107a1b4ee36bd1214b11285b77768d2e3824aedafa988fd36ee6"
+dependencies = [
+ "finl_unicode",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
@@ -1345,14 +2770,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.3.34"
+name = "thread_local"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -1367,12 +2804,21 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -1440,6 +2886,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls 0.23.4",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1468,6 +2936,62 @@ dependencies = [
  "tokio",
  "tracing",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
+dependencies = [
+ "indexmap 2.2.6",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
 
 [[package]]
 name = "tower-service"
@@ -1505,6 +3029,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1536,7 +3086,7 @@ dependencies = [
  "rustls-pki-types",
  "sha1",
  "thiserror",
- "url",
+ "url 2.5.0",
  "utf-8",
 ]
 
@@ -1560,14 +3110,14 @@ checksum = "eb704842c709bc76f63e99e704cb208beeccca2abbabd0d9aec02e48ca1cee0f"
 dependencies = [
  "chrono",
  "dashmap",
- "hashbrown",
+ "hashbrown 0.14.3",
  "mini-moka",
  "parking_lot",
  "secrecy",
  "serde_json",
  "time",
  "typesize-derive",
- "url",
+ "url 2.5.0",
 ]
 
 [[package]]
@@ -1580,6 +3130,12 @@ dependencies = [
  "quote",
  "syn 2.0.58",
 ]
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "unicase"
@@ -1612,10 +3168,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
+dependencies = [
+ "idna 0.1.5",
+ "matches",
+ "percent-encoding 1.0.1",
+]
 
 [[package]]
 name = "url"
@@ -1624,10 +3203,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
- "idna",
- "percent-encoding",
+ "idna 0.5.0",
+ "percent-encoding 2.3.1",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"
@@ -1640,6 +3225,18 @@ name = "uwl"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4bf03e0ca70d626ecc4ba6b0763b934b6f2976e8c744088bb3c1d646fbb1ad0"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -1671,6 +3268,12 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -1777,6 +3380,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
+]
+
+[[package]]
+name = "whoami"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44ab49fad634e88f55bf8f9bb3abd2f27d7204172a112c7c9987e01c1c94ea9"
+dependencies = [
+ "redox_syscall",
+ "wasite",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1813,7 +3438,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -1831,7 +3456,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -1851,17 +3476,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.4",
- "windows_aarch64_msvc 0.52.4",
- "windows_i686_gnu 0.52.4",
- "windows_i686_msvc 0.52.4",
- "windows_x86_64_gnu 0.52.4",
- "windows_x86_64_gnullvm 0.52.4",
- "windows_x86_64_msvc 0.52.4",
+ "windows_aarch64_gnullvm 0.52.5",
+ "windows_aarch64_msvc 0.52.5",
+ "windows_i686_gnu 0.52.5",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.5",
+ "windows_x86_64_gnu 0.52.5",
+ "windows_x86_64_gnullvm 0.52.5",
+ "windows_x86_64_msvc 0.52.5",
 ]
 
 [[package]]
@@ -1872,9 +3498,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1884,9 +3510,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1896,9 +3522,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1908,9 +3540,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1920,9 +3552,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1932,9 +3564,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1944,9 +3576,18 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+
+[[package]]
+name = "winnow"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c976aaaa0e1f90dbb21e9587cdaf1d9679a1cde8875c0d6bd83ab96a208352"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"
@@ -1956,6 +3597,62 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
+
+[[package]]
+name = "yup-oauth2"
+version = "8.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45b7ff561fdc7809a2adad8bce73e157d01129074098e6405d0d7dfa2d087782"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64 0.21.7",
+ "futures",
+ "http 0.2.12",
+ "hyper 0.14.28",
+ "hyper-rustls 0.25.0",
+ "itertools 0.12.1",
+ "log",
+ "percent-encoding 2.3.1",
+ "rustls 0.22.3",
+ "rustls-pemfile 1.0.4",
+ "seahash",
+ "serde",
+ "serde_json",
+ "time",
+ "tokio",
+ "tower-service",
+ "url 2.5.0",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "discalen"
+version = "0.1.0"
+authors = ["Anton Parfonov <antonparfonov@gmail.com>"]
+edition = "2021"
+description = "A bot to notify your discord server about upcoming events"
+repository = "https://github.com/YBoy-git/discalen"
+license = "MIT"
+keywords = ["discord", "bot"]
+
+[dependencies]
+anyhow = "1.0.81"
+chrono = "0.4.37"
+config = "0.14.0"
+dotenvy = "0.15.7"
+futures = "0.3.30"
+google-calendar3 = "5.0.4"
+humantime = "2.1.0"
+humantime-serde = "1.1.1"
+hyper = "1.2.0"
+hyper-rustls = "0.27.0"
+secrecy = "0.8.0"
+serde = { version = "1.0.197", features = ["derive"] }
+serenity = "0.12.1"
+sqlx = { version = "0.7.4", features = ["tls-rustls", "postgres", "runtime-tokio"] }
+thiserror = "1.0.58"
+tokio = { version = "1.37.0", features = ["macros", "rt-multi-thread"] }
+tracing = "0.1.40"
+tracing-subscriber = "0.3.18"
+yup-oauth2 = "8.3.3"
+
+[lints.rust]
+future-incompatible = "warn"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,44 @@
 # discalen
 
 A bot to notify your discord server about upcoming events
+
+## Commands
+
+Note: any command can return error due to Google API long responses. Don't panic if see a red message.
+
+- `/create_calendar` - create a calendar (admins only).
+- `/delete_calendar` - delete server calendars (admins only).
+- `/list_events` - list all the events, show calendar url.
+- `/create_event <label> <date>` - create an event (admins only).
+- `/delete_event <label>` - delete an event (admins only).
+- `/set_event_channel` - make the event channel receive event notifications (admins only).
+- `/ping` - is bot alive?
+
+## Testing in Discord
+
+There's the link to add the bot: https://discord.com/oauth2/authorize?client_id=1225950004909314170&permissions=2048&scope=bot
+
+Add the bot to a server and play with its functionality.
+
+## Building locally (if you are experienced enough, and really want it running locally)
+
+### Prerequisites
+
+- A Google service account with Calendar API
+- A Discord app with message content intent
+- docker
+- psql
+- cargo sqlx-cli
+
+### Step-by-step
+
+Note: not sure if the `init_db.sh` script will work on Windows, tested on Linux
+
+1. Insert your Google service account key into `secrets/google-sa-secret.json`
+2. Insert your Discord App token into `secrets/discord-token.txt`
+3. Insert your postgres db password into `secrets/db_password.txt`
+4. Configure the app config, mainly db connection (defaults should be ok)
+5. Create `.env` file with `DATABASE_URL` field (`DATABASE_URL="postgres://..."`) pointing to your local db
+6. `chmod +x scripts/inti_db.sh` (grant execution permissions)
+7. `./scripts/init_db.sh`
+8. `cargo r`

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,5 @@
+notification_period = "4h"
+db.user = "postgres"
+db.host = "localhost"
+db.port = 5432
+db.name = "event_channels"

--- a/migrations/20240413075802_create_event_channels.sql
+++ b/migrations/20240413075802_create_event_channels.sql
@@ -1,0 +1,4 @@
+CREATE TABLE event_channels(
+    guild_id VARCHAR(20) PRIMARY KEY,
+    channel_id VARCHAR(20) NOT NULL
+)

--- a/scripts/init_db.sh
+++ b/scripts/init_db.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -x
+set -eo pipefail
+
+if ! [ -x "$(command -v psql)" ]
+then
+    echo >&2 "Error: psql is not installed."
+    exit 1
+fi
+
+if ! [ -x "$(command -v sqlx)" ]
+then
+    echo >&2 "Error: sqlx is not installed."
+    echo >&2 "Use:"
+    echo >&2 "
+    cargo install --version=0.5.7 sqlx-cli --no-default-features --features postgres"
+    echo >&2 "to install it."
+    exit 1
+fi
+
+DB_USER=${POSTGRES_USER:=postgres}
+DB_PASSWORD="${POSTGRES_PASSWORD:=password}"
+DB_NAME="event_channels"
+DB_PORT="5432"
+
+if [ -z "${SKIP_DOCKER}" ]
+then
+docker run \
+    -e POSTGRES_USER=${DB_USER} \
+    -e POSTGRES_PASSWORD=${DB_PASSWORD} \
+    -e POSTGRES_DB=${DB_NAME} \
+    -p "${DB_PORT}":5432 \
+    -d postgres \
+    postgres -N 1000
+fi
+
+export PGPASSWORD="${DB_PASSWORD}"
+until psql -h "localhost" -U "${DB_USER}" -p "${DB_PORT}" -d "${DB_NAME}" -c "\q"; do
+    >&2 echo "Postgres is still unavailable - sleeping"
+    sleep 1
+done
+
+>&2 echo "Postgres is up and running on port ${DB_PORT}!"
+
+export DATABASE_URL=postgres://${DB_USER}:${DB_PASSWORD}@localhost:${DB_PORT}/${DB_NAME}
+sqlx db create
+sqlx mig run

--- a/src/calendar.rs
+++ b/src/calendar.rs
@@ -1,0 +1,171 @@
+use google_calendar3::{
+    api::{AclRule, AclRuleScope, Calendar, CalendarListEntry, Event},
+    hyper, hyper_rustls, CalendarHub,
+};
+use serenity::{all::GuildId, prelude::TypeMapKey};
+use tracing::{instrument, warn};
+use yup_oauth2::{
+    hyper::Client as CalendarClient, parse_service_account_key, ServiceAccountAuthenticator,
+};
+
+use crate::Error;
+
+pub type MyCalendarHub =
+    CalendarHub<hyper_rustls::HttpsConnector<hyper::client::connect::HttpConnector>>;
+
+pub async fn authenticate_calendar_hub(key: impl AsRef<[u8]>) -> Result<MyCalendarHub, Error> {
+    let sa_key = parse_service_account_key(key)?;
+    let auth = ServiceAccountAuthenticator::builder(sa_key).build().await?;
+
+    let https_connector = hyper_rustls::HttpsConnectorBuilder::new()
+        .with_native_roots()
+        .https_or_http()
+        .enable_http1()
+        .build();
+    let client = CalendarClient::builder().build(https_connector);
+
+    Ok(CalendarHub::new(client, auth))
+}
+
+#[derive(Clone)]
+pub struct Client {
+    pub calendar_hub: MyCalendarHub,
+}
+
+impl TypeMapKey for Client {
+    type Value = Self;
+}
+
+impl Client {
+    pub async fn with_sa_key(key: impl AsRef<[u8]>) -> Result<Self, Error> {
+        Ok(Self {
+            calendar_hub: authenticate_calendar_hub(key.as_ref()).await?,
+        })
+    }
+}
+
+impl Client {
+    #[instrument(skip(self))]
+    pub async fn create_calendar(&self, name: &str) -> Result<Calendar, Error> {
+        let calendar = Calendar {
+            summary: Some(name.to_string()),
+            ..Default::default()
+        };
+        let calendar = self
+            .calendar_hub
+            .calendars()
+            .insert(calendar)
+            .doit()
+            .await?
+            .1;
+
+        let rule = AclRule {
+            role: Some("reader".into()),
+            scope: Some(AclRuleScope {
+                type_: Some("default".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        self.calendar_hub
+            .acl()
+            .insert(rule, calendar.id.as_ref().expect("No calendar id"))
+            .doit()
+            .await?;
+        Ok(calendar)
+    }
+
+    #[instrument(skip(self))]
+    pub async fn delete_calendar(&self, calendar_id: &str) -> Result<(), Error> {
+        self.calendar_hub
+            .calendars()
+            .delete(calendar_id)
+            .doit()
+            .await?;
+        Ok(())
+    }
+
+    #[instrument(skip(self))]
+    pub async fn create_event(&self, event: Event, calendar_id: &str) -> Result<Event, Error> {
+        Ok(self
+            .calendar_hub
+            .events()
+            .insert(event, calendar_id)
+            .doit()
+            .await?
+            .1)
+    }
+
+    #[instrument(skip(self))]
+    pub async fn delete_event(&self, id: &str, calendar_id: &str) -> Result<(), Error> {
+        self.calendar_hub
+            .events()
+            .delete(calendar_id, id)
+            .doit()
+            .await?;
+        Ok(())
+    }
+
+    #[instrument(skip(self))]
+    pub async fn list_calendars(&self) -> Result<Vec<CalendarListEntry>, Error> {
+        Ok(self
+            .calendar_hub
+            .calendar_list()
+            .list()
+            .doit()
+            .await?
+            .1
+            .items
+            .expect("No items"))
+    }
+
+    #[instrument(skip(self))]
+    pub async fn list_events(&self, calendar_id: &str) -> Result<Vec<Event>, Error> {
+        Ok(self
+            .calendar_hub
+            .events()
+            .list(calendar_id)
+            .doit()
+            .await?
+            .1
+            .items
+            .expect("No items"))
+    }
+
+    #[instrument(skip(self))]
+    pub async fn get_calendars_by_guild_id(
+        &self,
+        guild_id: &GuildId,
+    ) -> Result<Option<CalendarListEntry>, Error> {
+        let mut response = self.list_calendars().await?;
+        response.retain(|calendar| calendar.summary == Some(guild_id.to_string()));
+        if response.len() > 1 {
+            warn!("More than one calendar associated with the server, using the newest one");
+        };
+        Ok(response.pop())
+    }
+
+    #[instrument(skip(self))]
+    pub async fn get_event_id_by_label(
+        &self,
+        label: &str,
+        calendar_id: &str,
+    ) -> Result<Vec<String>, Error> {
+        let response = self.list_events(calendar_id).await?;
+        let value = response
+            .into_iter()
+            .filter_map(|event| {
+                if event.summary.as_deref() == Some(label) {
+                    Some(event.id.expect("No event id"))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        Ok(value)
+    }
+}
+
+pub fn get_calendar_url(calendar_id: &str) -> String {
+    format!("https://calendar.google.com/calendar/u/0?cid={calendar_id}")
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,65 @@
+use std::{fs, path::Path, time::Duration};
+
+use config::Config;
+use secrecy::{ExposeSecret, Secret};
+use serde::Deserialize;
+
+use crate::Error;
+
+#[derive(Deserialize)]
+pub struct AppConfig {
+    #[serde(with = "humantime_serde")]
+    pub notification_period: Duration,
+    pub discord_access_token: Secret<String>,
+    pub google_secret: Secret<String>,
+    pub db: DbConfig,
+}
+
+#[derive(Deserialize)]
+pub struct DbConfig {
+    pub user: String,
+    pub password: Secret<String>,
+    pub host: String,
+    pub port: u16,
+    pub name: String,
+}
+
+impl DbConfig {
+    pub fn get_connection_url(&self) -> Secret<String> {
+        format!(
+            "postgres://{}:{}@{}:{}",
+            self.user,
+            self.password.expose_secret(),
+            self.host,
+            self.port
+        )
+        .into()
+    }
+
+    pub fn get_database_url(&self) -> Secret<String> {
+        format!(
+            "{}/{}",
+            self.get_connection_url().expose_secret(),
+            self.name
+        )
+        .into()
+    }
+}
+
+impl AppConfig {
+    pub fn load(secrets_path: impl AsRef<Path>) -> Result<Self, Error> {
+        let secrets_path = secrets_path.as_ref();
+
+        let config = Config::builder();
+        let config = config.add_source(config::File::with_name("config"));
+        let discord_token = fs::read_to_string(secrets_path.join("discord-token.txt"))?;
+        let config = config.set_override("discord_access_token", discord_token)?;
+        let google_secret = fs::read_to_string(secrets_path.join("google-sa-secret.json"))?;
+        let config = config.set_override("google_secret", google_secret)?;
+        let db_password = fs::read_to_string(secrets_path.join("db_password.txt"))?;
+        let config = config.set_override("db.password", db_password)?;
+        let config = config.build()?;
+
+        Ok(config.try_deserialize()?)
+    }
+}

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -1,0 +1,5 @@
+mod client;
+pub use client::*;
+mod commands;
+mod handler;
+pub use handler::*;

--- a/src/discord/client.rs
+++ b/src/discord/client.rs
@@ -1,0 +1,58 @@
+use serenity::all::{ChannelId, GuildId};
+use sqlx::{query, PgPool};
+
+pub struct Client {
+    pub serenity_client: serenity::Client,
+}
+
+impl Client {
+    pub async fn new(client: serenity::Client) -> Self {
+        Self {
+            serenity_client: client,
+        }
+    }
+}
+
+pub async fn set_event_channel(
+    pool: &PgPool,
+    guild_id: &GuildId,
+    channel_id: &ChannelId,
+) -> Result<(), crate::Error> {
+    query!(
+        "
+        DELETE FROM event_channels WHERE guild_id = $1
+        ",
+        guild_id.get().to_string()
+    )
+    .execute(pool)
+    .await?;
+    query!(
+        "
+        INSERT INTO event_channels(guild_id, channel_id)
+        VALUES($1, $2)
+        ON CONFLICT DO NOTHING
+        ",
+        guild_id.get().to_string(),
+        channel_id.get().to_string(),
+    )
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+pub async fn get_event_channel_id(
+    pool: &PgPool,
+    guild_id: &GuildId,
+) -> Result<Option<ChannelId>, crate::Error> {
+    let response = query!(
+        "
+        SELECT channel_id FROM event_channels
+        WHERE guild_id = $1
+        ",
+        guild_id.get().to_string()
+    )
+    .fetch_optional(pool)
+    .await?
+    .and_then(|record| Some(ChannelId::from(record.channel_id.parse::<u64>().ok()?)));
+    Ok(response)
+}

--- a/src/discord/commands.rs
+++ b/src/discord/commands.rs
@@ -1,0 +1,11 @@
+use crate::Error;
+
+pub mod create_calendar;
+pub mod create_event;
+pub mod delete_calendar;
+pub mod delete_event;
+pub mod list_events;
+pub mod ping;
+pub mod set_event_channel;
+
+pub type MessageResult = Result<String, Error>;

--- a/src/discord/commands/create_calendar.rs
+++ b/src/discord/commands/create_calendar.rs
@@ -1,0 +1,44 @@
+use crate::{calendar::Client as CalendarClient, Error};
+use serenity::all::{Context, CreateCommand, GuildId, Permissions, ResolvedOption};
+use tracing::{info, instrument};
+
+use crate::calendar::get_calendar_url;
+
+use super::MessageResult;
+
+#[instrument]
+pub async fn run(
+    ctx: &Context,
+    guild_id: GuildId,
+    _options: &[ResolvedOption<'_>],
+) -> MessageResult {
+    info!("Creating a calendar");
+    let lock = ctx.data.read().await;
+    let calendar_client = lock
+        .get::<CalendarClient>()
+        .ok_or(Error::NoCalendarClient)?;
+    let calendars = calendar_client.get_calendars_by_guild_id(&guild_id).await?;
+    if calendars.is_some() {
+        return Ok(format!(
+            "A calendar already exists: {}",
+            calendars
+                .into_iter()
+                .map(|calendar| {
+                    let calendar_id = calendar.id.expect("No calendar id");
+                    get_calendar_url(&calendar_id)
+                })
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+    calendar_client
+        .create_calendar(&guild_id.to_string())
+        .await?;
+    Ok("Created the calendar! `/list_events` to get the url".into())
+}
+
+pub fn register() -> CreateCommand {
+    CreateCommand::new("create_calendar")
+        .description("Create a new event calendar for the server, removing the old")
+        .default_member_permissions(Permissions::ADMINISTRATOR)
+}

--- a/src/discord/commands/create_event.rs
+++ b/src/discord/commands/create_event.rs
@@ -1,0 +1,92 @@
+use std::str::FromStr;
+
+use crate::{calendar::Client as CalendarClient, Error};
+use chrono::{Datelike, Days, NaiveDate, Utc};
+use google_calendar3::api::{Event, EventDateTime};
+use serenity::all::{
+    CommandOptionType, Context, CreateCommand, CreateCommandOption, GuildId, Permissions,
+    ResolvedOption, ResolvedValue,
+};
+use tracing::{instrument, warn};
+
+use super::MessageResult;
+
+#[instrument]
+pub async fn run(
+    ctx: &Context,
+    guild_id: &GuildId,
+    options: &[ResolvedOption<'_>],
+) -> MessageResult {
+    let Some(ResolvedOption {
+        value: ResolvedValue::String(label),
+        ..
+    }) = options.first()
+    else {
+        return Err(Error::MissingParameter("label".into()));
+    };
+
+    let date = match options.get(1) {
+        Some(ResolvedOption {
+            value: ResolvedValue::String(date),
+            ..
+        }) => {
+            let year = Utc::now().year();
+            let date = format!("{year}-{date}");
+            NaiveDate::from_str(&date)?
+        }
+        _ => Utc::now().date_naive(),
+    };
+
+    let event = Event {
+        summary: Some(label.to_string()),
+        start: Some(EventDateTime {
+            date: Some(date),
+            ..Default::default()
+        }),
+        end: Some(EventDateTime {
+            date: Some(
+                date.checked_add_days(Days::new(1))
+                    .expect("Out of range days"),
+            ),
+            ..Default::default()
+        }),
+        recurrence: Some(vec!["RRULE:FREQ=YEARLY".into()]),
+        ..Default::default()
+    };
+
+    let lock = ctx.data.read().await;
+    let calendar_client = lock
+        .get::<CalendarClient>()
+        .ok_or(Error::NoCalendarClient)?;
+
+    let calendars = calendar_client.get_calendars_by_guild_id(guild_id).await?;
+    let Some(calendar) = calendars else {
+        warn!("Couldn't find a calendar for the guild");
+        return Ok("No calendar for the server, create a new one! `/create_calendar`".into());
+    };
+
+    let calendar_id = calendar.id.expect("No calendar id");
+    calendar_client.create_event(event, &calendar_id).await?;
+
+    Ok(format!(
+        "The event \"{label}\" was created successfully! Date: {date}"
+    ))
+}
+
+pub fn register() -> CreateCommand {
+    CreateCommand::new("create_event")
+        .description("Create an event with a label on a specific date")
+        .add_option(
+            CreateCommandOption::new(CommandOptionType::String, "label", "The label of the event")
+                .required(true),
+        )
+        .add_option(
+            CreateCommandOption::new(
+                CommandOptionType::String,
+                "date",
+                "The date of the event using the MM-DD format. Default is today",
+            )
+            .required(false),
+        )
+        .default_member_permissions(Permissions::ADMINISTRATOR)
+}

--- a/src/discord/commands/delete_calendar.rs
+++ b/src/discord/commands/delete_calendar.rs
@@ -1,0 +1,35 @@
+use crate::{calendar::Client as CalendarClient, Error};
+use serenity::all::{Context, CreateCommand, GuildId, Permissions, ResolvedOption};
+use tracing::{info, instrument};
+
+use super::MessageResult;
+
+#[instrument]
+pub async fn run(
+    ctx: &Context,
+    guild_id: GuildId,
+    _options: &[ResolvedOption<'_>],
+) -> MessageResult {
+    info!("Deleting calendars");
+    let lock = ctx.data.read().await;
+    let calendar_client = lock
+        .get::<CalendarClient>()
+        .ok_or(Error::NoCalendarClient)?;
+    let calendars = calendar_client.get_calendars_by_guild_id(&guild_id).await?;
+
+    let mut handles = vec![];
+    for calendar in &calendars {
+        let calendar_id = calendar.id.as_ref().expect("No calendar id");
+        let handle = calendar_client.delete_calendar(calendar_id);
+        handles.push(handle);
+    }
+    futures::future::join_all(handles).await;
+
+    Ok("Deleted calendars!".into())
+}
+
+pub fn register() -> CreateCommand {
+    CreateCommand::new("delete_calendar")
+        .description("Delete the event calendar associated with the server")
+        .default_member_permissions(Permissions::ADMINISTRATOR)
+}

--- a/src/discord/commands/delete_event.rs
+++ b/src/discord/commands/delete_event.rs
@@ -1,0 +1,61 @@
+use crate::{calendar::Client as CalendarClient, Error};
+use serenity::all::{
+    CommandOptionType, Context, CreateCommand, CreateCommandOption, GuildId, Permissions,
+    ResolvedOption, ResolvedValue,
+};
+use tracing::{info, instrument, warn};
+
+use super::MessageResult;
+
+#[instrument]
+pub async fn run(
+    ctx: &Context,
+    guild_id: &GuildId,
+    options: &[ResolvedOption<'_>],
+) -> MessageResult {
+    let Some(ResolvedOption {
+        value: ResolvedValue::String(label),
+        ..
+    }) = options.first()
+    else {
+        return Err(Error::MissingParameter("label".into()));
+    };
+
+    let lock = ctx.data.read().await;
+    let calendar_client = lock
+        .get::<CalendarClient>()
+        .ok_or(Error::NoCalendarClient)?;
+    let calendars = calendar_client.get_calendars_by_guild_id(guild_id).await?;
+    let Some(calendar) = calendars else {
+        warn!("Couldn't find a calendar for the guild");
+        return Ok("No calendar for the server, create a new one! `/create_calendar`".into());
+    };
+    let calendar_id = calendar.id.expect("No calendar id");
+
+    let event_ids = calendar_client
+        .get_event_id_by_label(label, &calendar_id)
+        .await?;
+    info!(?event_ids, "Deleting these events");
+
+    let mut handles = Vec::with_capacity(event_ids.len());
+    for id in &event_ids {
+        let handle = calendar_client.delete_event(id, &calendar_id);
+        handles.push(handle);
+    }
+    futures::future::join_all(handles).await;
+
+    Ok(format!(
+        "Deleted {} events from the calendar!",
+        event_ids.len()
+    ))
+}
+
+pub fn register() -> CreateCommand {
+    CreateCommand::new("delete_event")
+        .description("Delete events with the specified label")
+        .add_option(
+            CreateCommandOption::new(CommandOptionType::String, "label", "The label of the event")
+                .required(true),
+        )
+        .default_member_permissions(Permissions::ADMINISTRATOR)
+}

--- a/src/discord/commands/list_events.rs
+++ b/src/discord/commands/list_events.rs
@@ -1,0 +1,71 @@
+use crate::{calendar::Client as CalendarClient, Error};
+use serenity::all::{Context, CreateCommand, GuildId, ResolvedOption};
+use tracing::{info, instrument, warn};
+
+use crate::calendar::get_calendar_url;
+
+use super::MessageResult;
+
+#[instrument]
+pub async fn run(
+    ctx: &Context,
+    guild_id: &GuildId,
+    _options: &[ResolvedOption<'_>],
+) -> MessageResult {
+    info!("Fetching an event list for a guild");
+    let lock = ctx.data.read().await;
+    let calendar_client = lock
+        .get::<CalendarClient>()
+        .ok_or(Error::NoCalendarClient)?;
+
+    let calendars = calendar_client.get_calendars_by_guild_id(guild_id).await?;
+
+    let calendar = match calendars {
+        Some(calendar) => calendar.id.expect("No calendar id"),
+        None => {
+            warn!("No calendar found for the server, escaping...");
+            return Ok(
+                "No calendar found for the server! Create a new one using `/create_calendar`"
+                    .into(),
+            );
+        }
+    };
+
+    let events = calendar_client.list_events(&calendar).await?;
+
+    info!(?events, "Returned event list");
+
+    Ok(format!(
+        "Events:\n{}\nCalendar: {}",
+        events
+            .into_iter()
+            .map(|event| {
+                let label = event.summary.unwrap_or_else(|| {
+                    warn!(event_id = event.id, "No label for the event");
+                    "No label".into()
+                });
+                let date = match event.start {
+                    Some(start) => match start.date {
+                        Some(date) => date.to_string(),
+                        None => {
+                            warn!(event_id = event.id, "No date for the event");
+                            "No date".into()
+                        }
+                    }
+                    .to_string(),
+                    None => {
+                        warn!(event_id = event.id, "No start for the event");
+                        "No start".into()
+                    }
+                };
+                format!("{}: {}", label, date)
+            })
+            .collect::<Vec<_>>()
+            .join("\n"),
+        get_calendar_url(&calendar)
+    ))
+}
+
+pub fn register() -> CreateCommand {
+    CreateCommand::new("list_events").description("List all the events on the server")
+}

--- a/src/discord/commands/ping.rs
+++ b/src/discord/commands/ping.rs
@@ -1,0 +1,10 @@
+use serenity::builder::CreateCommand;
+use serenity::model::application::ResolvedOption;
+
+pub fn run(_options: &[ResolvedOption<'_>]) -> String {
+    "Hey, I'm alive!".to_string()
+}
+
+pub fn register() -> CreateCommand {
+    CreateCommand::new("ping").description("A ping command")
+}

--- a/src/discord/commands/set_event_channel.rs
+++ b/src/discord/commands/set_event_channel.rs
@@ -1,0 +1,29 @@
+use serenity::all::{ChannelId, Context, GuildId, Permissions};
+use serenity::builder::CreateCommand;
+use serenity::model::application::ResolvedOption;
+use tracing::{info, instrument};
+
+use crate::discord::set_event_channel;
+use crate::Error;
+
+use super::MessageResult;
+
+#[instrument]
+pub async fn run(
+    ctx: &Context,
+    guild_id: GuildId,
+    channel_id: ChannelId,
+    _options: &[ResolvedOption<'_>],
+) -> MessageResult {
+    info!("Setting the event channel");
+    let lock = ctx.data.read().await;
+    let pool = lock.get::<crate::Pool>().ok_or(Error::NoPool)?;
+    set_event_channel(pool, &guild_id, &channel_id).await?;
+    Ok("The channel is set as the event channel for the server!".into())
+}
+
+pub fn register() -> CreateCommand {
+    CreateCommand::new("set_event_channel")
+        .description("The channel will be receiving notifications about any current events")
+        .default_member_permissions(Permissions::ADMINISTRATOR)
+}

--- a/src/discord/handler.rs
+++ b/src/discord/handler.rs
@@ -1,0 +1,139 @@
+use crate::discord::commands;
+use crate::{calendar::Client as CalendarClient, Error};
+use serenity::{
+    all::{
+        Context, CreateInteractionResponse, CreateInteractionResponseMessage, EventHandler, Guild,
+        GuildId, Http, Interaction, Ready,
+    },
+    async_trait,
+};
+use tracing::{error, info, instrument, warn};
+
+use super::commands::MessageResult;
+
+#[derive(Debug)]
+pub struct Handler;
+
+#[async_trait]
+impl EventHandler for Handler {
+    #[instrument]
+    async fn guild_create(&self, ctx: Context, guild: Guild, is_new: Option<bool>) {
+        match is_new {
+            None => warn!("Caching is off, can't identify if there are any new servers!"),
+            Some(is_new) => {
+                if is_new {
+                    info!("Added to {} server", guild.name);
+                    if let Err(why) = create_calendar(&ctx, guild.name).await {
+                        error!(?why, "Failed to create calendar");
+                    };
+                    init_commands(&ctx.http, &guild.id).await;
+                }
+            }
+        }
+    }
+
+    #[instrument]
+    async fn ready(&self, ctx: Context, ready: Ready) {
+        info!("{} is connected!", ready.user.name);
+
+        let guilds = ready.guilds.iter().map(|guild| &guild.id);
+        let mut handles = Vec::with_capacity(guilds.len());
+        for guild in guilds {
+            handles.push(init_commands(&ctx.http, guild));
+        }
+        futures::future::join_all(handles).await;
+    }
+
+    #[instrument]
+    async fn interaction_create(&self, ctx: Context, interaction: Interaction) {
+        if let Interaction::Command(command) = interaction {
+            info!(?command, "Received command interaction");
+
+            let Some(guild_id) = command.guild_id else {
+                error!("No guild_id found, cancelling");
+                return;
+            };
+            let channel_id = command.channel_id;
+            let options = command.data.options();
+
+            let content = match command.data.name.as_ref() {
+                "ping" => Some(commands::ping::run(&options)),
+                "create_calendar" => Some(result_to_message(
+                    commands::create_calendar::run(&ctx, guild_id, &options).await,
+                )),
+                "delete_calendar" => Some(result_to_message(
+                    commands::delete_calendar::run(&ctx, guild_id, &options).await,
+                )),
+                "set_event_channel" => Some(result_to_message(
+                    commands::set_event_channel::run(&ctx, guild_id, channel_id, &options).await,
+                )),
+                "list_events" => Some(result_to_message(
+                    commands::list_events::run(&ctx, &guild_id, &options).await,
+                )),
+                "create_event" => Some(result_to_message(
+                    commands::create_event::run(&ctx, &guild_id, &options).await,
+                )),
+                "delete_event" => Some(result_to_message(
+                    commands::delete_event::run(&ctx, &guild_id, &options).await,
+                )),
+                command => {
+                    error!("An unimplemented command met: {command}");
+                    Some("not implemented".to_string())
+                }
+            };
+
+            if let Some(content) = content {
+                let data = CreateInteractionResponseMessage::new()
+                    .content(content)
+                    .ephemeral(true);
+                let builder = CreateInteractionResponse::Message(data);
+                if let Err(why) = command.create_response(&ctx.http, builder).await {
+                    error!("Cannot respond to slash command: {why}");
+                }
+            }
+        }
+    }
+}
+
+#[instrument]
+async fn create_calendar(ctx: &Context, name: String) -> Result<(), Error> {
+    info!("Pushing a calendar to queue");
+    ctx.data
+        .read()
+        .await
+        .get::<CalendarClient>()
+        .ok_or(Error::NoCalendarClient)?
+        .create_calendar(&name)
+        .await?;
+    Ok(())
+}
+
+async fn init_commands(http: &Http, guild: &GuildId) {
+    if let Err(why) = guild
+        .set_commands(
+            http,
+            vec![
+                commands::ping::register(),
+                commands::create_calendar::register(),
+                commands::delete_calendar::register(),
+                commands::set_event_channel::register(),
+                commands::list_events::register(),
+                commands::create_event::register(),
+                commands::delete_event::register(),
+            ],
+        )
+        .await
+    {
+        error!(?why, "Failed to create a command");
+    };
+}
+
+fn result_to_message(result: MessageResult) -> String {
+    match result {
+        Ok(message) => message,
+        Err(why) => {
+            error!(?why, "Failed to execute the command");
+            format!("Error: {why}")
+        }
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,38 @@
+use serenity::all::GuildId;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("The calendar summary {0} is not a discord server id")]
+    CalendarSummaryNotDiscordServerId(String),
+
+    #[error("The server {0} has no event channel")]
+    DiscordSeverHasNoEventChannel(GuildId),
+
+    #[error("No pool in data")]
+    NoPool,
+
+    #[error("No calendar client in data")]
+    NoCalendarClient,
+
+    #[error("Required parameter {0} is missing")]
+    MissingParameter(String),
+
+    #[error(transparent)]
+    DbError(#[from] sqlx::Error),
+
+    #[error(transparent)]
+    GoogleError(#[from] google_calendar3::Error),
+
+    #[error(transparent)]
+    IoError(#[from] std::io::Error),
+
+    #[error(transparent)]
+    ConfigError(#[from] config::ConfigError),
+
+    #[error(transparent)]
+    SerenityError(#[from] serenity::Error),
+
+    #[error(transparent)]
+    ChronoParseError(#[from] chrono::ParseError),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,158 @@
+use std::sync::Arc;
+
+use calendar::Client as CalendarClient;
+use chrono::Utc;
+use config::AppConfig;
+use discord::Client as DiscordClient;
+use discord::Handler;
+use futures::StreamExt;
+use google_calendar3::api::CalendarListEntry;
+use google_calendar3::api::Event;
+use google_calendar3::api::EventDateTime;
+use secrecy::ExposeSecret;
+use serenity::all::CreateMessage;
+use serenity::all::GuildId;
+use serenity::all::Http;
+use serenity::prelude::*;
+use serenity::Client as SerenityClient;
+use sqlx::PgPool;
+use tokio::task::JoinHandle;
+use tracing::error;
+use tracing::instrument;
+use tracing::warn;
+
+pub mod config;
+
+mod calendar;
+mod discord;
+
+mod error;
+pub use error::*;
+
+pub struct Pool;
+
+impl TypeMapKey for Pool {
+    type Value = PgPool;
+}
+
+pub struct Client {
+    discord_client: DiscordClient,
+}
+
+impl Client {
+    pub async fn run(config: AppConfig, pool: PgPool) -> Result<(), Error> {
+        let intents = GatewayIntents::GUILD_MESSAGES
+            | GatewayIntents::MESSAGE_CONTENT
+            | GatewayIntents::GUILDS;
+
+        let calendar_client =
+            CalendarClient::with_sa_key(config.google_secret.expose_secret()).await?;
+
+        let serenity_client =
+            SerenityClient::builder(config.discord_access_token.expose_secret(), intents)
+                .event_handler(Handler)
+                .await?;
+        let serenity_data = serenity_client.data.clone();
+        {
+            let mut data = serenity_data.write().await;
+            data.insert::<CalendarClient>(calendar_client.clone());
+            data.insert::<Pool>(pool);
+        }
+
+        let discalen_client = Self {
+            discord_client: DiscordClient::new(serenity_client).await,
+        };
+        let discord_client = discalen_client.discord_client;
+        let sender_http = discord_client.serenity_client.http.clone();
+        let discord_data = discord_client.serenity_client.data.clone();
+
+        let discord_task = tokio::spawn(async move {
+            let mut serenity_client = discord_client.serenity_client;
+            if let Err(why) = serenity_client.start_autosharded().await {
+                error!("Client error: {why:?}");
+            }
+        });
+
+        let calendar_task: JoinHandle<Result<(), Error>> = tokio::spawn(async move {
+            let calendar_client = calendar_client;
+            loop {
+                tokio::time::sleep(config.notification_period).await;
+
+                let calendars = calendar_client.list_calendars().await?;
+
+                let mut calendars_handles = vec![];
+                for calendar in &calendars {
+                    let handle =
+                        calendar_client.list_events(calendar.id.as_ref().expect("No id specified"));
+                    calendars_handles.push((calendar, handle));
+                }
+
+                let mut stream = futures::stream::iter(calendars_handles);
+                while let Some(handle) = stream.next().await {
+                    let (calendar, events) = handle;
+                    let events = events.await?;
+
+                    let mut sending_tasks = vec![];
+                    for event in events {
+                        let date = match event.start {
+                            Some(EventDateTime {
+                                date: Some(date), ..
+                            }) => date,
+                            _ => {
+                                warn!(?event, "The event doesn't have the start date, skipping...");
+                                continue;
+                            }
+                        };
+                        if date == Utc::now().date_naive() {
+                            sending_tasks.push(send_event_notification(
+                                discord_data.clone(),
+                                &sender_http,
+                                calendar,
+                                event,
+                            ));
+                        }
+                    }
+                    futures::future::join_all(sending_tasks).await;
+                }
+            }
+        });
+
+        tokio::select! {
+            _ = discord_task => (),
+            _ = calendar_task => (),
+        };
+
+        Ok(())
+    }
+}
+
+#[instrument(skip(data))]
+async fn send_event_notification(
+    data: Arc<RwLock<TypeMap>>,
+    sender_http: &Http,
+    calendar: &CalendarListEntry,
+    event: Event,
+) -> Result<(), Error> {
+    let lock = data.read().await;
+    let summary = calendar.summary.as_ref().expect("No calendar summary");
+    let guild_id = summary
+        .parse()
+        .map_err(|_| Error::CalendarSummaryNotDiscordServerId(summary.into()))?;
+    let guild_id = GuildId::new(guild_id);
+    let pool = lock.get::<Pool>().ok_or(Error::NoPool)?;
+    let Some(channel_id) = discord::get_event_channel_id(pool, &guild_id).await? else {
+        warn!(?guild_id, "The server has no event channel");
+        return Err(Error::DiscordSeverHasNoEventChannel(guild_id));
+    };
+    let message = CreateMessage::new().content(format!(
+        "Today is {}, have a nice celebration!🎉",
+        match event.summary.as_ref() {
+            Some(summary) => summary.as_str(),
+            None => "No label",
+        }
+    ));
+    sender_http
+        .send_message(channel_id, vec![], &message)
+        .await?;
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,27 @@
+use std::env;
+
+use anyhow::{Context, Result};
+use discalen::config::AppConfig;
+use secrecy::ExposeSecret;
+use sqlx::PgPool;
+use tracing::instrument;
+
+#[instrument]
+#[tokio::main]
+async fn main() -> Result<()> {
+    let _ = dotenvy::dotenv();
+    tracing_subscriber::fmt().init();
+
+    let secrets_path = format!(
+        "{}/secrets",
+        env::var("CARGO_MANIFEST_DIR").context("Couldn't read CARGO_MANIFEST_DIR")?
+    );
+    let config = AppConfig::load(secrets_path).context("Failed to init the config")?;
+    let pool = PgPool::connect(config.db.get_database_url().expose_secret())
+        .await
+        .context("Failed to connect to db")?;
+
+    discalen::Client::run(config, pool).await?;
+
+    Ok(())
+}


### PR DESCRIPTION
The previous PR: https://github.com/YBoy-git/discalen/pull/1

# discalen

A bot to notify your discord server about upcoming events

## Commands

Note: any command can return error due to Google API long responses. Don't panic if see a red message.

- `/create_calendar` - create a calendar (admins only).
- `/delete_calendar` - delete server calendars (admins only).
- `/list_events` - list all the events, show calendar url.
- `/create_event <label> <date>` - create an event (admins only).
- `/delete_event <label>` - delete an event (admins only).
- `/set_event_channel` - make the event channel receive event notifications (admins only).
- `/ping` - is bot alive?

## Testing in Discord

There's the link to add the bot: https://discord.com/oauth2/authorize?client_id=1225950004909314170&permissions=2048&scope=bot

Add the bot to a server and play with its functionality.

## Building locally (if you are experienced enough, and really want it running locally)

### Prerequisites

- A Google service account with Calendar API
- A Discord app with message content intent
- docker
- psql
- cargo sqlx-cli

### Step-by-step

Note: not sure if the `init_db.sh` script will work on Windows, tested on Linux

1. Insert your Google service account key into `secrets/google-sa-secret.json`
2. Insert your Discord App token into `secrets/discord-token.txt`
3. Insert your postgres db password into `secrets/db_password.txt`
4. Configure the app config, mainly db connection (defaults should be ok)
5. Create `.env` file with `DATABASE_URL` field (`DATABASE_URL="postgres://..."`) pointing to your local db
6. `chmod +x scripts/inti_db.sh` (grant execution permissions)
7. `./scripts/init_db.sh`
8. `cargo r`